### PR TITLE
Update hep_cli_installer_dev.sh

### DIFF
--- a/hep_cli_installer_dev.sh
+++ b/hep_cli_installer_dev.sh
@@ -36,7 +36,7 @@ echo -e "************************************************************"
 yum install hepic-installer -y
 
 elif [ -n "$(command -v apt-get)" ];then
-
+apt-get install gnupg
 cat > /etc/apt/sources.list.d/qxip_hepic-dev.list << 'EOF'
 deb https://0000-0000-0000-deb:@packagecloud.io/qxip/hepic-dev/any/ any main
 deb-src https://0000-0000-0000-deb:@packagecloud.io/qxip/hepic-dev/any/ any main
@@ -44,6 +44,7 @@ EOF
 
 echo -e "Please insert the provided key to install hep_cli:"
 read key
+        curl -L https://$key:@packagecloud.io/qxip/hepic/gpgkey | apt-key add -
         sed -i "s/0000-0000-0000-deb/$key/g" /etc/apt/sources.list.d/qxip_hepic-dev.list
 
   echo -n "Running apt-get update... "


### PR DESCRIPTION
gpgkey error fix for debian. This was already done for prod hep_cli_installer script.