### PR TITLE
Replace apt-key with signed-by keyrings in hep_cli_installer.sh

### DIFF
--- a/hep_cli_installer.sh
+++ b/hep_cli_installer.sh
@@ -38,19 +38,18 @@ yum install -y hepic-installer
 
 elif [ -n "$(command -v apt-get)" ];then
 apt-get install -y sudo gnupg curl
-cat > /etc/apt/sources.list.d/qxip_hepic.list << 'EOF'
-deb https://0000-0000-0000-deb:@packagecloud.io/qxip/hepic/any/ any main
-deb-src https://0000-0000-0000-deb:@packagecloud.io/qxip/hepic/any/ any main
-EOF
-
+sudo install -m 0755 -d /etc/apt/keyrings
 echo -e "Please insert the provided key to install hep_cli:"
 read key
-        curl -L https://$key:@packagecloud.io/qxip/hepic/gpgkey | apt-key add -
-        sed -i "s/0000-0000-0000-deb/$key/g" /etc/apt/sources.list.d/qxip_hepic.list
-
-  echo -n "Running apt-get update... "
-  apt-get update &> /dev/null
-  echo "done."
+curl -fsSL "https://${key}:@packagecloud.io/qxip/hepic/gpgkey" | sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/hepic.gpg
+cat > /etc/apt/sources.list.d/qxip_hepic.list << 'EOF'
+deb [signed-by=/etc/apt/keyrings/hepic.gpg] https://0000-0000-0000-deb:@packagecloud.io/qxip/hepic/any/ any main
+deb-src [signed-by=/etc/apt/keyrings/hepic.gpg] https://0000-0000-0000-deb:@packagecloud.io/qxip/hepic/any/ any main
+EOF
+sed -i "s/0000-0000-0000-deb/$key/g" /etc/apt/sources.list.d/qxip_hepic.list
+echo -n "Running apt-get update... "
+apt-get update &> /dev/null
+echo "done."
 
 
 echo -e "************************************************************"


### PR DESCRIPTION
## Summary
- Debian 13 removed `apt-key`, so the production installer can no longer import the Packagecloud GPG key that way.
- Mirror the already-working `hep_cli_installer_dev.sh` path: store the key in `/etc/apt/keyrings/hepic.gpg` and pin it with `signed-by=` in `qxip_hepic.list`.
- `--batch --yes` lets a re-run overwrite the keyring instead of failing because the file already exists.

Fixes #7

This supersedes #8, which dropped `apt-key` but never added `signed-by=`, so apt would not use the new keyring.

## Test plan
- [x] On Debian 13: run `hep_cli_installer.sh`, confirm `apt-key` is not invoked and `hepic-installer` installs
- [x] On Debian 12 / Ubuntu 22.04+: same installer still works
- [ ] Re-run the script and confirm the keyring overwrite does not fail
- [ ] Confirm `/etc/apt/sources.list.d/qxip_hepic.list` contains `signed-by=/etc/apt/keyrings/hepic.gpg`